### PR TITLE
Fixed issue where multiple implementations of the same closed generic…

### DIFF
--- a/Monument.Test/BaselineTypePatterns.cs
+++ b/Monument.Test/BaselineTypePatterns.cs
@@ -126,7 +126,8 @@ namespace Monument.Test
                  typeof(OpenGenericImplementation3<>)));
 
         [TestMethod]
-        public void ClosedGenericListRegistration() { 
+        public void ClosedAndOpenGenericListRegistration()
+        {
             Assert.AreEqual(2, Get<IEnumerable<IGenericInterface<SimpleImplementation2>>>(
                 typeof(OpenGenericImplementation1<>),
                 typeof(ClosedGenericImplementation1),
@@ -138,13 +139,22 @@ namespace Monument.Test
         }
 
         [TestMethod]
-        public void ClosedGenericRegistration() {
+        public void ClosedGenericRegistration()
+        {
             Assert.IsNotNull(Get<IGenericInterface<SimpleImplementation2>>(
                 typeof(ClosedGenericImplementation1),
                 typeof(ClosedGenericImplementation4)));
             Assert.IsNotNull(Get<IGenericInterface<SimpleImplementation1>>(
                 typeof(ClosedGenericImplementation1),
                 typeof(ClosedGenericImplementation4)));
+        }
+
+        [TestMethod]
+        public void ClosedGenericListRegistration()
+        {
+            Assert.AreEqual(2, Get<IEnumerable<IGenericInterface<SimpleImplementation1>>>(
+                typeof(ClosedGenericImplementation1),
+                typeof(ClosedGenericImplementation2)).Count());
         }
     }
 


### PR DESCRIPTION
… were trying to be registered as a single registration multiple times. The problem was grouping equality in the generic arguements array.